### PR TITLE
Remove red panda mascot from page UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from 'react'
 import ProjectCard from './components/ProjectCard'
 import ProjectList from './components/ProjectList'
-import RedPandaMascot from './components/RedPandaMascot'
 import ViewToggle from './components/ViewToggle'
 import { useView, ViewProvider } from './context/ViewContext'
 import { projects } from './data/projects'
@@ -40,23 +39,15 @@ function AppContent() {
         </div>
 
         <div className="relative max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-16">
-          <div className="flex items-center gap-6 sm:gap-8">
-            {/* Mascot */}
-            <div className="shrink-0 animate-fade-in">
-              <RedPandaMascot size={100} variant="full" className="hidden sm:block" />
-              <RedPandaMascot size={64} variant="head" className="sm:hidden" />
-            </div>
-
-            <div>
-              <h1 className="text-5xl sm:text-6xl lg:text-7xl font-bold tracking-tight animate-fade-in">
-                <span className="bg-gradient-to-r from-white via-white to-zinc-500 bg-clip-text text-transparent">
-                  sed.fyi
-                </span>
-              </h1>
-              <p className="mt-4 text-lg sm:text-xl text-zinc-400 max-w-2xl animate-slide-up">
-                Open-source development tools built for the modern web.
-              </p>
-            </div>
+          <div>
+            <h1 className="text-5xl sm:text-6xl lg:text-7xl font-bold tracking-tight animate-fade-in">
+              <span className="bg-gradient-to-r from-white via-white to-zinc-500 bg-clip-text text-transparent">
+                sed.fyi
+              </span>
+            </h1>
+            <p className="mt-4 text-lg sm:text-xl text-zinc-400 max-w-2xl animate-slide-up">
+              Open-source development tools built for the modern web.
+            </p>
           </div>
         </div>
       </header>
@@ -128,10 +119,7 @@ function AppContent() {
       <footer className="border-t border-white/[0.06] mt-auto">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           <div className="flex flex-col sm:flex-row justify-between items-center gap-4">
-            <div className="flex items-center gap-2">
-              <RedPandaMascot size={24} variant="head" />
-              <p className="text-zinc-600 text-sm">&copy; {new Date().getFullYear()} sed.fyi</p>
-            </div>
+            <p className="text-zinc-600 text-sm">&copy; {new Date().getFullYear()} sed.fyi</p>
             <nav aria-label="Footer links" className="flex items-center gap-6">
               <a
                 href="https://github.com/gregnazario"


### PR DESCRIPTION
Removes the red panda mascot from the live page UI.

## Changes

Scoped entirely to `src/App.tsx`:

- Removed the `RedPandaMascot` import
- **Hero:** dropped both mascot variants (100px `full` on desktop, 64px `head` on mobile) and collapsed the `flex` wrapper that existed only to sit the mascot beside the title
- **Footer:** dropped the 24px `head` icon and its wrapper, leaving the copyright text directly in the flex row

## Not changed

- `public/favicon.svg`, `favicon.png`, `apple-touch-icon.png` — kept intentionally
- `public/og-image.svg` / `og-image.png` — the social share card still shows the mascot; it is not part of the page UI
- `src/components/RedPandaMascot.tsx` — now unreferenced by the app but retained, since the favicon art derives from the same design. It is tree-shaken out of the bundle.

## Verification

- `bun run typecheck` — clean
- `bun run lint` (biome) — clean, 23 files
- `bun run build` — succeeds
- Headless screenshot of the built site confirms the hero and footer render correctly with no leftover gaps

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes in a single file with no routing, data, or auth impact.
> 
> **Overview**
> Removes the **red panda mascot** from the live sed.fyi page so the hero and footer are text-only.
> 
> In **`App.tsx`**, the `RedPandaMascot` import and all usages are dropped: responsive hero mascots (`full` / `head`) and the footer icon beside the copyright. The hero no longer uses the side-by-side flex wrapper—title and tagline sit in a simple block. The footer keeps the same link row with copyright text only.
> 
> `RedPandaMascot.tsx` and favicon/OG assets are unchanged; the component is unused in the app bundle but retained for shared artwork.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29e3385163e95e6cec7fd4802f714bf327844d80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
