### PR TITLE
Configure Dependabot for Bun and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  # JavaScript dependencies. This project uses Bun (bun.lock); the "bun"
+  # ecosystem keeps package.json and bun.lock updated together.
+  - package-ecosystem: "bun"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      # Batch routine dev-tooling bumps into a single PR to reduce noise.
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Keep the actions used by .github/workflows/deploy.yml current.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Adds `.github/dependabot.yml` so Dependabot targets this project's actual package manager.

## Why

This repo has no Dependabot config, so Dependabot fell back to default detection. PRs #3 and #4 were opened against `package-lock.json` before the Bun migration, then went stale: commit `b0600a1` (2026-02-03) deleted `package-lock.json` and added `bun.lock` in the same commit. Both PRs became unmergeable (modify/delete conflicts) and were closed as obsolete.

## Changes

- `package-ecosystem: "bun"` — updates `package.json` and `bun.lock` together. Dependabot's Bun support has been GA since February 2025.
- `package-ecosystem: "github-actions"` — `.github/workflows/deploy.yml` currently pins `actions/checkout@v3`, `actions/setup-node@v3` and `peaceiris/actions-gh-pages@v3`, all behind their current majors.
- Weekly schedule, 5 open-PR cap per ecosystem.
- Routine dev-dependency minor/patch bumps are grouped into a single PR to limit noise. Security updates are unaffected by grouping and still arrive individually.

## Verification

- YAML validated with `yq`; both ecosystem keys parse as expected.
- No application code touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/automation config only; no runtime, auth, or application logic changes.
> 
> **Overview**
> Introduces **`.github/dependabot.yml`** so dependency updates match how the repo is built today (Bun + `bun.lock`) instead of default tooling that previously opened obsolete `package-lock.json` PRs.
> 
> **Bun ecosystem** (`directory: /`): weekly updates with up to 5 open PRs; dev-dependency **minor/patch** bumps are **grouped** into one PR to cut noise (security updates stay ungrouped).
> 
> **GitHub Actions ecosystem**: same weekly schedule and PR cap, aimed at keeping workflow pins (e.g. `actions/checkout@v3`, `setup-node@v3`, `peaceiris/actions-gh-pages@v3` in deploy) current.
> 
> No application or workflow file changes in this PR—config only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19e3a4e6763ab445b74a962de07a521a5ae16a88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->