### PR TITLE
Add CI workflow for typecheck, lint and build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,10 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  # Keep the verification workflow's actions current.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+# Verification only. Deployment is handled by Vercel, which builds on push.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Cancel superseded runs on the same ref instead of queueing them.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Typecheck, lint and build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Build
+        run: bun run build


### PR DESCRIPTION
Adds `.github/workflows/ci.yml` so type errors and lint failures are caught before merge.

## Why

Vercel builds every push, and its `buildCommand` is `bun run build` (`tsc && vite build`), so a type error already blocks production. But Vercel never runs `bun run lint`.

Since #17 removed the last workflow, **nothing has checked Biome in CI**. The Biome 2.5 migration in #18 — schema bump, `recommended` -> `preset`, and two SVG `<title>` additions — passed on local verification alone. This closes that gap.

## What it does

- Triggers on pull requests and pushes to `main`
- `oven-sh/setup-bun@v2`, then `bun install --frozen-lockfile`
- Runs `typecheck`, `lint`, then `build`
- `concurrency` with `cancel-in-progress` so superseded runs are cancelled rather than queued
- `permissions: contents: read` — read-only, no deploy

This **verifies only**. It does not deploy, so it does not reintroduce the redundancy that made the old GitHub Pages workflow dead weight.

## Also

Restores the `github-actions` Dependabot ecosystem, dropped in #17 because no workflows remained. One exists again, so it has something to track.

## Verification

- Both YAML files validated with `yq`
- `bun install --frozen-lockfile` succeeds locally — the exact install CI runs, confirming `bun.lock` is in sync with `package.json`
- `bun run typecheck`, `bun run lint`, `bun run build` all pass on this branch

The workflow's own first run on this PR is the real test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI and dependency automation; no application runtime or auth/data paths are modified.
> 
> **Overview**
> Adds a **CI workflow** that runs on pull requests and pushes to `main`, executing `typecheck`, `lint`, and `build` with Bun (`frozen-lockfile` install). The job is verification-only (read-only `contents` permission, no deploy) and uses **concurrency** with cancel-in-progress to drop stale runs on the same ref.
> 
> **Dependabot** is extended with a weekly `github-actions` ecosystem entry so workflow action versions stay updated now that a workflow exists again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e881d359f925fc9436395a7c850074c3d612e65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->