### PR TITLE
CI: run test suite; docs: correct setup commands to bun

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
         run: bun run build
 
       - name: Test
-        run: bun test
+        run: bun run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Lint
         run: bun run lint
 
-      - name: Build
-        run: bun run build
-
       - name: Test
         run: bun run test
+
+      - name: Build
+        run: bun run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   check:
-    name: Typecheck, lint and build
+    name: Typecheck, lint, build and test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -36,3 +36,6 @@ jobs:
 
       - name: Build
         run: bun run build
+
+      - name: Test
+        run: bun test

--- a/README.md
+++ b/README.md
@@ -14,27 +14,27 @@ A static website that explains how to run a dev tool across different operating 
 
 1. Install dependencies:
    ```bash
-   npm install
+   bun install
    ```
 
 2. Start the development server:
    ```bash
-   npm run dev
+   bun run dev
    ```
 
 3. Build for production:
    ```bash
-   npm run build
+   bun run build
    ```
 
 4. Preview the production build:
    ```bash
-   npm run preview
+   bun run preview
    ```
 
 5. Type checking:
    ```bash
-   npm run typecheck
+   bun run typecheck
    ```
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ runner. If you don't have it yet:
 curl -fsSL https://bun.sh/install | bash
 ```
 
+On Windows (PowerShell):
+
+```powershell
+powershell -c "irm bun.sh/install.ps1 | iex"
+```
+
 1. Install dependencies:
    ```bash
    bun install

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ A static website that explains how to run a dev tool across different operating 
 
 ## Development
 
+This project uses [Bun](https://bun.sh/) as its package manager and test
+runner. If you don't have it yet:
+
+```bash
+curl -fsSL https://bun.sh/install | bash
+```
+
 1. Install dependencies:
    ```bash
    bun install


### PR DESCRIPTION
- Add a `bun test` step to the CI workflow so the test suite runs alongside typecheck, lint and build.
- README setup docs referenced `npm install`/`npm run dev`, but the project is bun-based (bun.lock, Vercel builds with bun). Updated to `bun install`, `bun run dev`, etc.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow and documentation only; no application or deployment logic changes.
> 
> **Overview**
> **CI** now runs the test suite (`bun run test`) after lint and before build, and the check job is renamed to reflect that.
> 
> **README** development instructions are updated from npm to Bun (`bun install`, `bun run dev`, etc.) and adds short Bun install steps for Unix and Windows so setup matches `bun.lock` and Vercel’s build command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3107c3faf58a65de959038f5fabfbba6834f1543. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->